### PR TITLE
Document saturating behavior of addition and multiplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
   - npm install purescript pulp bower purescript-psa
   - bower install
 script:
-  - pulp build --censor-lib
+  - pulp build -- --censor-lib
   - pulp test

--- a/src/Data/Int53.purs
+++ b/src/Data/Int53.purs
@@ -125,7 +125,29 @@ instance genericInt53 :: Generic Int53 where
 
     fromSpine _ = Nothing
 
-
+-- | Addition is saturating:
+-- |
+-- | ```
+-- | >>> top + fromInt 1 == top
+-- | true
+-- | ```
+-- |
+-- | NOTE: Due to this, Int53 doesn't actually satisfy the associativity law
+-- | for addition:
+-- |
+-- | ```
+-- | >>> top + (fromInt 1 + fromInt (-1))
+-- | (Int53 9007199254740991.0)
+-- | >>> (top + fromInt 1) + fromInt (-1)
+-- | (Int53 9007199254740990.0)
+-- | ```
+-- |
+-- | Multiplication is also saturating:
+-- |
+-- | ```
+-- | >>> top * fromInt 2 == top
+-- | true
+-- | ```
 instance semiringInt53 :: Semiring Int53 where
     add (Int53 a) (Int53 b) = unsafeClamp $ add a b
     zero = Int53 zero


### PR DESCRIPTION
Arithmetic operations on `Int53` saturate on `bottom` and `top`. This may be non-obvious, since most in most languages integers wrap around instead. Instance documentation should clarify that.