### PR TITLE
Updates for ps-0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,16 +16,15 @@
     "output"
   ],
   "dependencies": {
-    "purescript-generics": "^4.0.0",
     "purescript-math": "^2.0.0",
-    "purescript-integers": "^3.0.0"
+    "purescript-integers": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0",
-    "purescript-aff": "^4.0.0",
-    "purescript-random": "^3.0.0",
-    "purescript-quickcheck-laws": "^3.0.0",
-    "purescript-test-unit": "^13.0.0"
+    "purescript-console": "^4.1.0",
+    "purescript-aff": "^5.0.1",
+    "purescript-random": "^4.0.0",
+    "purescript-quickcheck-laws": "^4.0.0",
+    "purescript-test-unit": "^14.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {},
   "devDependencies": {
     "pulp": "^12.3.0",
-    "purescript": "^0.12.0"
+    "purescript": "slamdata/node-purescript#0.12",
   },
   "scripts": {
     "test": "pulp test"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {},
   "devDependencies": {
     "pulp": "^12.3.0",
-    "purescript": "slamdata/node-purescript#0.12",
+    "purescript": "slamdata/node-purescript#0.12"
   },
   "scripts": {
     "test": "pulp test"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {},
   "devDependencies": {
     "pulp": "^12.3.0",
-    "purescript": "^0.11.7"
+    "purescript": "^0.12.0"
   },
   "scripts": {
     "test": "pulp test"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "purescript-int-53",
   "dependencies": {},
   "devDependencies": {
-    "pulp": "^12.0.1",
+    "pulp": "^12.3.0",
     "purescript": "^0.11.7"
   },
   "scripts": {

--- a/src/Data/Int53.purs
+++ b/src/Data/Int53.purs
@@ -38,9 +38,6 @@
 -- | However, that includes the `Int53` tag in the resulting string, so you might
 -- | sometimes want [`toString`](#v:toString) instead.
 -- |
--- | There is also now an instance of `Data.Generic`, which you might find helpful in cases
--- | where an `Int53` is part of a larger data structure which you would like to make `Generic`.
--- |
 -- | ### The `Int53Value` class
 -- |
 -- | There is also a class for [`Int53Value`](#t:Int53Value), which might sometimes be useful if you
@@ -65,7 +62,7 @@ import Prelude
     , class Bounded, top, bottom
     , class Eq, class Ord
     , class Show, show
-    , (==), ($), (<>), (>), (<), negate, not, (<<<), (||), id, unit, (>>=), (>>>)
+    , (==), ($), (<>), (>), (<), negate, not, (<<<), (||), identity, (>>>)
     )
 
 import Math as Math
@@ -73,7 +70,6 @@ import Global (readFloat, isNaN)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Int (toNumber, floor) as Int
 import Data.String (Pattern(..), stripSuffix)
-import Data.Generic (class Generic, GenericSpine(..), GenericSignature(..), toSpine, fromSpine)
 
 
 -- Internally, an Int53 is a newtype over a `Number`. We implement the various
@@ -97,33 +93,6 @@ import Data.Generic (class Generic, GenericSpine(..), GenericSignature(..), toSp
 -- | There's also `top` and `bottom` from `Bounded`, which indicate the maximum
 -- | and minimum values available for an `Int53`.
 newtype Int53 = Int53 Number
-
-
--- A convenience for the `Generic` instance.
-qualifiedName :: String
-qualifiedName = "Data.Int53.Int53"
-
-
--- We don't want to just derive a `Generic` instance, because then you could use
--- `fromSpine` to construct an `Int53` that isn't really an integer. So, we use
--- `fromNumber` below to prevent that.
-instance genericInt53 :: Generic Int53 where
-    toSignature _ =
-        SigProd qualifiedName
-            [ { sigConstructor: qualifiedName
-              , sigValues: [ \_ -> SigNumber ]
-              }
-            ]
-
-    toSpine (Int53 n) =
-        SProd qualifiedName [\_ -> toSpine n]
-
-    fromSpine (SProd qName [n]) | qName == qualifiedName =
-        -- This is where we use `fromNumber` to return `Nothing` if the generic
-        -- value is not actually an `Integer`
-        fromSpine (n unit) >>= fromNumber
-
-    fromSpine _ = Nothing
 
 -- | Addition is saturating:
 -- |
@@ -395,8 +364,8 @@ class Int53Value a where
 
 
 instance int53Int53Value :: Int53Value Int53 where
-    toInt53 = id
-    fromInt53 = id
+    toInt53 = identity
+    fromInt53 = identity
 
 
 instance intInt53Value :: Int53Value Int where

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,57 +1,32 @@
 module Test.Main where
 
-import Test.Unit (Test, test)
-import Test.Unit.Main (runTest)
-import Test.Unit.Console (TESTOUTPUT)
-import Test.Unit.Assert (equal, assert)
-import Test.Unit.QuickCheck (quickCheck)
+import Data.Int53
 
+import Data.Int as Int
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Aff (Aff)
+import Effect.Class (liftEffect)
+import Global (nan)
+import Prelude (class Bounded, class CommutativeRing, class Eq, class EuclideanRing, class Ord, class Ring, class Semiring, class Show, Unit, add, bind, bottom, degree, discard, div, flip, mod, mul, negate, one, pure, show, sub, top, zero, ($), (*), (+), (-), (>))
 import Test.QuickCheck ((===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Gen (choose)
-
+import Test.QuickCheck.Laws.Data.Bounded (checkBounded)
+import Test.QuickCheck.Laws.Data.CommutativeRing (checkCommutativeRing)
+import Test.QuickCheck.Laws.Data.Eq (checkEq)
+import Test.QuickCheck.Laws.Data.EuclideanRing (checkEuclideanRing)
+import Test.QuickCheck.Laws.Data.Ord (checkOrd)
+import Test.QuickCheck.Laws.Data.Ring (checkRing)
+import Test.QuickCheck.Laws.Data.Semiring (checkSemiring)
+import Test.Unit (test)
+import Test.Unit.Assert (equal)
+import Test.Unit.Main (runTest)
+import Test.Unit.QuickCheck (quickCheck)
 import Type.Proxy (Proxy(..))
 
-import Test.QuickCheck.Laws.Data.CommutativeRing (checkCommutativeRing)
-import Test.QuickCheck.Laws.Data.EuclideanRing (checkEuclideanRing)
-import Test.QuickCheck.Laws.Data.Semiring (checkSemiring)
-import Test.QuickCheck.Laws.Data.Bounded (checkBounded)
-import Test.QuickCheck.Laws.Data.Ring (checkRing)
-import Test.QuickCheck.Laws.Data.Eq (checkEq)
-import Test.QuickCheck.Laws.Data.Ord (checkOrd)
 
-import Data.Int53
-import Data.Maybe (Maybe(..))
-import Data.Int as Int
-import Data.Generic (GenericSpine(..), isValidSpine, toSpine, fromSpine, toSignature)
-import Global (nan)
-
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Random (RANDOM)
-import Control.Monad.Eff.Console (CONSOLE)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Aff.AVar (AVAR)
-
-import Prelude
-    ( class Bounded, top, bottom, class Ord, class Eq
-    , class Semiring, add, zero, mul, one
-    , class Ring, sub
-    , class EuclideanRing, degree, div, mod
-    , class CommutativeRing
-    , class Show, show
-    , Unit, pure, bind, negate, ($), flip, (+), (*), (-), (>)
-    , discard
-    )
-
-
-main :: Eff
-    ( avar :: AVAR
-    , testOutput :: TESTOUTPUT
-    , random :: RANDOM
-    , console :: CONSOLE
-    , exception :: EXCEPTION
-    ) Unit
+main :: Effect Unit
 
 main = runTest do
     test "truncate" do
@@ -169,19 +144,8 @@ main = runTest do
         show (fromInt (-27)) ==> "(Int53 -27.0)"
         show (fromInt (0)) ==> "(Int53 0.0)"
 
-    test "generics" do
-        assert "isValidSpine" $ isValidSpine (toSignature (Proxy :: Proxy Int53)) (toSpine (fromInt 27))
-
-        -- Check that toSpine and fromSpine round-trip
-        quickCheck \a ->
-            fromSpine (toSpine (fromInt a)) === Just (fromInt a)
-
-        -- Check that you can't construct a non-integer via generics
-        fromSpine (SProd "Data.Int53.Int53" [\_ -> SNumber 27.0]) ==> Just (fromInt 27)
-        fromSpine (SProd "Data.Int53.Int53" [\_ -> SNumber 28.3]) ==> (Nothing :: Maybe Int53)
-
     test "laws\n" $
-        liftEff do
+        liftEffect do
             checkSemiring proxyInt53
             checkBounded proxyInt53
             checkRing proxyInt53
@@ -192,7 +156,7 @@ main = runTest do
 
 infixl 9 equals as ==>
 
-equals :: ∀ a e. Eq a => Show a => a -> a -> Test e
+equals :: ∀ a. Eq a => Show a => a -> a -> Aff Unit
 equals = flip equal
 
 


### PR DESCRIPTION
I'm not sure if we are able to provide safe `Generic` instance because we have `Generic.Rep.to :: rep -> a` and there is no way to fail when transforming representation into value, so it is expected that this should probably should "work" as it typechecks:

```purescript
(x ∷ Int53) = to ((Constructor (Argument 8.5)) ∷ Constructor "Int53" (Argument Number))
```