### PR TITLE
Add missing `purescript-strings` dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
   ],
   "dependencies": {
     "purescript-math": "^2.0.0",
-    "purescript-integers": "^4.0.0"
+    "purescript-integers": "^4.0.0",
+    "purescript-strings": "^4.0.1"
   },
   "devDependencies": {
     "purescript-console": "^4.1.0",


### PR DESCRIPTION
Re: https://github.com/jystic/purescript-jack/pull/26#discussion_r276309473

The `purescript-strings` dependency was missing, and occasionally causing errors attempting to use this package downstream.

You can validate the failure before these changes by running:
```
$ bower install --production
$ pulp build
```
See the first commit message for more information.